### PR TITLE
Only run post install in development only scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 node_modules
 dist
+.idea

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-tsdx lint
+npx tsdx lint

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ joe.name; // => Error! Can't access undefined key 'name' for object {twitterHand
 
 This project was bootstrapped with [TSDX](https://github.com/jaredpalmer/tsdx).
 
+Run `npx husky install` or `yarn husky install` to install the pre-commit hook.
+
+### Available commands
+
 Below is a list of commands you will probably find useful.
 
 ### `npm start` or `yarn start`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "dist"
   ],
   "scripts": {
-    "postinstall": "husky install",
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",


### PR DESCRIPTION
Hi @Schniz,

it's me again. I've tried to integrate the 0.1.1 version of `factoree` into my project, but it fails with
```
> factoree@0.1.1 postinstall /Users/xxx/yyy/node_modules/factoree
> husky install

sh: husky: command not found
```

After a quick looks around, I've stumbled upon this:

```
if your package is not private and you're publishing it on a registry like npmjs.com, you need to disable 
postinstall script using pinst. Otherwise, postinstall will run when someone installs your package and 
result in an error.
```

See https://typicode.github.io/husky/#/?id=install

So I've followed the instructions from husky and the result should (hopefully) fix the problem.

Regards,
急須