### PR TITLE
Allow partial nested objects

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -36,6 +36,9 @@ export function factory<T extends Object>(defaults?: Partial<T>): Factory<T> {
       },
       get(target: Partial<T>, p: keyof T) {
         if (target?.hasOwnProperty?.(p) || target[p]) {
+          if (typeof target[p] === 'object') {
+          return factory(target[p])();
+          }
           return target[p];
         } else if (isExceptionKey(p)) {
           return undefined;

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,5 +1,12 @@
 import { inspect } from 'util';
 
+type RecursivePartial<T> = {
+  [P in keyof T]?:
+    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+    T[P] extends object ? RecursivePartial<T[P]> :
+    T[P];
+};
+
 /**
  * A factory that will throw errors when accessing
  * an unsetted value
@@ -9,7 +16,7 @@ export type Factory<T> = (
    * Attributes to set for the instance.
    * These will extend and override the attributes provided to the `defaults` when the factory was created
    */
-  attributes?: Partial<T>
+  attributes?: RecursivePartial<T>
 ) => T;
 
 /**

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -44,3 +44,12 @@ it(`can be used in Promise.resolve`, async () => {
   const instance = await Promise.resolve(user({ name: 'Gal' }));
   expect(instance).toEqual({ name: 'Gal', github: 'Schniz' });
 });
+
+it(`allows partial in nested objects`, () => { 
+  const user = factory<User>({ github: 'deanshub' });
+  const instance = user({ permissions: { write: true } });
+  expect(instance).toEqual({
+    github: 'deanshub',
+    permissions: {write: true},
+  });
+})

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -3,6 +3,10 @@ import { factory } from '../src';
 interface User {
   name: string;
   github: string;
+  permissions: {
+    read: boolean;
+    write: boolean;
+  }
 }
 
 it('passes the overrides', () => {

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -56,4 +56,7 @@ it(`allows partial in nested objects`, () => {
     github: 'deanshub',
     permissions: {write: true},
   });
+  expect(() => {
+    console.log(instance.permissions.read);
+  }).toThrowError();
 })


### PR DESCRIPTION
When having an object nested inside an object, factoree won't allow partial.
This should fix it.